### PR TITLE
Adding missing dependencies

### DIFF
--- a/bot/util/color.py
+++ b/bot/util/color.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from interactions import Color
+from interactions import Color # pkg: pip install discord-py-interactions
 
 
 class Colors(Color, Enum):

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ uuid>=1.30
 yarl>=1.6.3
 virtualenv>=20.4.6
 lichesspy>=1.0.4
+discord-py-interactions>=5.11.0
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,5 @@ urllib3>=1.26.4
 uuid>=1.30
 yarl>=1.6.3
 virtualenv>=20.4.6
-lichesspy>=1.0.4
 discord-py-interactions>=5.11.0
 setuptools


### PR DESCRIPTION
Solution for the Issue: #75 

The error message that Python did not recognize the import is due to the fact that it was not installed at all.  The author had installed the package locally. Therefore it worked. I have now added it to the ``requirements.txt`` file. Now you can import it without any problems. 

PyPi Projekt: https://pypi.org/project/discord-py-interactions/

See: 
https://github.com/eskopp/faultybot/blob/a3eef91e01f0b5bd4991dd27946c166359572c40/requirements.txt#L22